### PR TITLE
Update circleci docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/buildpack-deps:stable-curl-browsers-legacy
+      - image: cimg/base:stable
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Fixed CircleCI deprecated Warning
> You’re using a deprecated Docker convenience image. Upgrade to a next-gen Docker convenience image.

Change docker image to `cimg/base:stable`